### PR TITLE
Bump strip-comments to 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "requires-regex": "^1.0.4",
-    "strip-comments": "^1.0.1"
+    "strip-comments": "^2.0.1"
   },
   "devDependencies": {
     "crequire": "^1.8.1",


### PR DESCRIPTION
Removes deprecated deeply nested corejs@2 dependency